### PR TITLE
Fix: Reset camera to default, previous AR enhancements

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,8 +104,8 @@
                 >
             </a-entity>
         </a-marker>
-        <!-- Adjusted camera position for a wider view, disabled manual camera controls -->
-        <a-entity camera position="0 1.6 2" look-controls="enabled: false" wasd-controls="enabled: false"></a-entity>
+        <!-- Camera reset to A-Frame/AR.js defaults -->
+        <a-entity camera></a-entity>
 
         <div id="instructions">
             Point camera at a Hiro marker. Pinch to scale model.


### PR DESCRIPTION
- Reset camera to A-Frame/AR.js default settings by removing explicit position and control attributes. This addresses the issue of the camera being too zoomed in.

Previous enhancements include:
- Redesigned model selection UI with thumbnails and a clearer layout.
- Implemented a loading indicator during model loading.
- Added error handling for `models.json` loading and individual model loading.
- Integrated gesture handling (pinch-to-scale) for models.
- Added on-screen instructions for user guidance.
- Structured `models.json` to include thumbnail paths and updated JS accordingly.
- Added placeholder and default thumbnails.
- Included `aframe-gesture-handler-component` for interactions.